### PR TITLE
Update Dependabot Configuration to Ignore NPM Major Version Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,12 @@ updates:
     schedule:
       interval: "monthly"
 
-  # Maintain dependencies for npm
+  # Maintain dependencies for npm (Next.js project)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to improve dependency management for the Next.js project. Specifically, it configures Dependabot to ignore all major version updates (`semver-major`) for NPM dependencies.

- Adds an `ignore` configuration for the NPM package ecosystem.
- Sets Dependabot to ignore updates of type `version-update:semver-major` for all NPM dependencies (`dependency-name: "*"`)

Ignoring major version updates helps prevent unexpected breaking changes from being automatically proposed by Dependabot. This allows to review and manage major upgrades manually, reducing the risk of introducing instability.